### PR TITLE
Return pod name in the `extra` field

### DIFF
--- a/lib/flame_k8s_backend.ex
+++ b/lib/flame_k8s_backend.ex
@@ -258,7 +258,7 @@ defmodule FLAMEK8sBackend do
         case created_pod do
           {:ok, pod} ->
             log(state, "Runner pod created and scheduled", pod_ip: pod["status"]["podIP"])
-            %{state | extra: pod}
+            %{state | extra: Map.get(pod, "name")}
   
           :error ->
             Logger.error("failed to schedule runner pod within #{state.boot_timeout}ms")

--- a/lib/flame_k8s_backend.ex
+++ b/lib/flame_k8s_backend.ex
@@ -164,7 +164,8 @@ defmodule FLAMEK8sBackend do
             remote_terminator_pid: nil,
             omit_owner_reference: false,
             log: false,
-            http: nil
+            http: nil,
+            extra: nil
 
   @valid_opts ~w(app_container_name runner_pod_tpl terminator_sup log boot_timeout omit_owner_reference)a
   @required_config ~w()a
@@ -257,8 +258,8 @@ defmodule FLAMEK8sBackend do
         case created_pod do
           {:ok, pod} ->
             log(state, "Runner pod created and scheduled", pod_ip: pod["status"]["podIP"])
-            state
-
+            %{state | extra: pod}
+  
           :error ->
             Logger.error("failed to schedule runner pod within #{state.boot_timeout}ms")
             exit(:timeout)

--- a/lib/flame_k8s_backend.ex
+++ b/lib/flame_k8s_backend.ex
@@ -258,9 +258,9 @@ defmodule FLAMEK8sBackend do
         case created_pod do
           {:ok, pod} ->
             log(state, "Runner pod created and scheduled", pod_ip: pod["status"]["podIP"])
-            state = %{state | extra: get_in(pod, ["managedFields", "name"])}
+            state = %{state | extra: get_in(pod, ["metadata", "name"])}
             require Logger
-            Logger.warning("POD: #{inspect(pod)}")
+            Logger.warning("POD: #{inspect(state.extra)}")
             state
   
           :error ->

--- a/lib/flame_k8s_backend.ex
+++ b/lib/flame_k8s_backend.ex
@@ -259,8 +259,6 @@ defmodule FLAMEK8sBackend do
           {:ok, pod} ->
             log(state, "Runner pod created and scheduled", pod_ip: pod["status"]["podIP"])
             state = %{state | extra: get_in(pod, ["metadata", "name"])}
-            require Logger
-            Logger.warning("POD: #{inspect(state.extra)}")
             state
   
           :error ->

--- a/lib/flame_k8s_backend.ex
+++ b/lib/flame_k8s_backend.ex
@@ -258,7 +258,10 @@ defmodule FLAMEK8sBackend do
         case created_pod do
           {:ok, pod} ->
             log(state, "Runner pod created and scheduled", pod_ip: pod["status"]["podIP"])
-            %{state | extra: get_in(pod, ["managedFields", "name"])}
+            state = %{state | extra: get_in(pod, ["managedFields", "name"])}
+            require Logger
+            Logger.warning("STATE: #{inspect(state)}")
+            state
   
           :error ->
             Logger.error("failed to schedule runner pod within #{state.boot_timeout}ms")

--- a/lib/flame_k8s_backend.ex
+++ b/lib/flame_k8s_backend.ex
@@ -260,7 +260,7 @@ defmodule FLAMEK8sBackend do
             log(state, "Runner pod created and scheduled", pod_ip: pod["status"]["podIP"])
             state = %{state | extra: get_in(pod, ["managedFields", "name"])}
             require Logger
-            Logger.warning("STATE: #{inspect(state)}")
+            Logger.warning("POD: #{inspect(pod)}")
             state
   
           :error ->

--- a/lib/flame_k8s_backend.ex
+++ b/lib/flame_k8s_backend.ex
@@ -258,7 +258,7 @@ defmodule FLAMEK8sBackend do
         case created_pod do
           {:ok, pod} ->
             log(state, "Runner pod created and scheduled", pod_ip: pod["status"]["podIP"])
-            %{state | extra: Map.get(pod, "name")}
+            %{state | extra: get_in(pod, ["managedFields", "name"])}
   
           :error ->
             Logger.error("failed to schedule runner pod within #{state.boot_timeout}ms")


### PR DESCRIPTION
This PR:
* returns pod name of the newly spawned runner as the `extra` field in the backend state returned by the `remote_boot` callback implementation

This change relies on a feature introduced in: https://github.com/varsill/flame/pull/1